### PR TITLE
Check if headers have been sent before setting cookie.

### DIFF
--- a/hm-messages.php
+++ b/hm-messages.php
@@ -42,6 +42,9 @@ function hm_success_message ( $message, $context = '' ) {
  * @return null
  */
 function hm_add_message( $message, $context = null, $type = 'success' ) {
+	if ( headers_sent() ) {
+		return;
+	}
 
 	global $hm_messages;
 	


### PR DESCRIPTION
Ensures `hm_add_message()` does not throw an error if headers have been sent.

Fixes #2 